### PR TITLE
add-firefox-support-for-scrollbars. and apply only for large screens.

### DIFF
--- a/resources/dist/app.css
+++ b/resources/dist/app.css
@@ -1,28 +1,41 @@
-::-webkit-scrollbar {
-    height: 5px;
-    width: 5px
-}
+@media (min-width: 768px) {
+    ::-webkit-scrollbar {
+        height: 5px;
+        width: 5px
+    }
 
-::-webkit-scrollbar-track {
-    background: #e5e7eb
-}
+    ::-webkit-scrollbar-track {
+        background: #e5e7eb
+    }
 
-::-webkit-scrollbar-thumb {
-    background: #d1d5db
-}
+    ::-webkit-scrollbar-thumb {
+        background: #d1d5db
+    }
 
-::-webkit-scrollbar-thumb:hover {
-    background: #c9cbcd
-}
+    ::-webkit-scrollbar-thumb:hover {
+        background: #c9cbcd
+    }
 
-.dark ::-webkit-scrollbar-track {
-    background: #101215
-}
+    .dark ::-webkit-scrollbar-track {
+        background: #101215
+    }
 
-.dark ::-webkit-scrollbar-thumb {
-    background: #1f2126
-}
+    .dark ::-webkit-scrollbar-thumb {
+        background: #1f2126
+    }
 
-.dark ::-webkit-scrollbar-thumb:hover {
-    background: #1a1d21
+    .dark ::-webkit-scrollbar-thumb:hover {
+        background: #1a1d21
+    }
+
+    @supports (-moz-appearance: none) {
+        * {
+            scrollbar-width: thin;
+            scrollbar-color: #d1d5db #e5e7eb;
+        }
+
+        .dark, .dark * {
+            scrollbar-color: #1f2126 #101215;
+        }
+    }
 }


### PR DESCRIPTION
### Changes:
- Added custom scrollbar styles that support Firefox using `-moz-appearance` because Firefox does not support `-webkit` prefixed scrollbar styling..

- The scrollbar styles are applied only for screens 768px or larger, so they won’t affect small screens (mobile devices) because the default scrollbar on small screens is better and no custom style is needed.

For more details on browser compatibility and the lack of `-webkit` support in Firefox, see [MDN Web Docs - Scrollbar styling](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar).

### **_before_**
![mKBxHPkcIO](https://github.com/user-attachments/assets/d8e671f1-ad08-49b3-9183-7ee9ded6636a)

### _**After**_
![firefox_6mCeJmi0lS](https://github.com/user-attachments/assets/303333ea-ae42-4a14-b3b8-d9ab3de660c2)
![firefox_djPwhdkiS2](https://github.com/user-attachments/assets/d2d7d2b7-d7b1-4909-80b2-a690dac73b51)

